### PR TITLE
Allow overwriting of existing files on Flysystem

### DIFF
--- a/Storage/FlysystemStorage.php
+++ b/Storage/FlysystemStorage.php
@@ -35,7 +35,7 @@ class FlysystemStorage extends AbstractStorage
         $path = !empty($dir) ? $dir.'/'.$name : $name;
 
         $stream = fopen($file->getRealPath(), 'r');
-        $fs->writeStream($path, $stream, [
+        $fs->putStream($path, $stream, [
             'mimetype' => $file->getMimeType(),
         ]);
     }


### PR DESCRIPTION
Allow overwriting of existing files when using Flysystem storage. Simply done by replacing writeStream() with putStream().